### PR TITLE
Change needed to run X11 apps. The VNC will be available on port 6080.

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,1 @@
+FROM gitpod/workspace-full-vnc

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,3 +4,11 @@ tasks:
 vscode:
   extensions:
      - https://open-vsx.org/api/tabajara-krausburg/jacamo4code/1.2.1/file/tabajara-krausburg.jacamo4code-1.2.1.vsix
+
+image:
+  file: .gitpod.Dockerfile
+ports:
+  - port: 5900
+    onOpen: ignore
+  - port: 6080
+    onOpen: open-browser


### PR DESCRIPTION
The change is based on [GitPod guide](6080) and I have to use that to be able to run JWT environment for my JAON project.